### PR TITLE
Added support for input that doesn't involve any Godot input actions.

### DIFF
--- a/addons/dialogue_nodes/objects/dialogueBox.gd
+++ b/addons/dialogue_nodes/objects/dialogueBox.gd
@@ -13,6 +13,7 @@ signal variable_changed(var_name, value)
 @export var start_id: String
 @export_range(1, 8) var max_options = 4
 @export_enum('Begin', 'Center', 'End') var options_alignment = 2: set = _set_options_alignment
+@export var input_action : String
 @export var custom_effects : Array[RichTextEffect] = [RichTextWait.new()]
 
 var speaker : Label
@@ -83,8 +84,12 @@ func _ready():
 
 
 func _input(event):
-	if Input.is_action_just_pressed("ui_accept"):
-		custom_effects[0].skip = true
+	if input_action == '':
+		if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+				custom_effects[0].skip = true
+	else:
+		if Input.is_action_just_pressed(input_action):
+			custom_effects[0].skip = true
 
 
 func load_file(path):

--- a/addons/dialogue_nodes/objects/dialogueBox.gd
+++ b/addons/dialogue_nodes/objects/dialogueBox.gd
@@ -86,7 +86,7 @@ func _ready():
 func _input(event):
 	if input_action == '':
 		if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
-				custom_effects[0].skip = true
+			custom_effects[0].skip = true
 	else:
 		if Input.is_action_just_pressed(input_action):
 			custom_effects[0].skip = true

--- a/examples/Demo.tscn
+++ b/examples/Demo.tscn
@@ -88,6 +88,7 @@ grow_vertical = 0
 script = ExtResource("8_kplwy")
 dialogue_file = "res://examples/Example1.json"
 start_id = "START"
+input_action = null
 custom_effects = Array[RichTextEffect]([SubResource("RichTextEffect_fpwbw")])
 
 [connection signal="item_selected" from="DemoSelector" to="." method="_on_demo_selected"]


### PR DESCRIPTION
The old version of the code to skip text boxes depended on having a "ui_accept" action, which is not always the case. By moving that option to a variable in the inspector, we offer both possiblities.

By default, if no action is set, it'll listen to both left mouse button and space as a way to skip text boxes.