### PR TITLE
Disabled scroll follow in DialogueBox.

### DIFF
--- a/addons/dialogue_nodes/objects/dialogueBox.gd
+++ b/addons/dialogue_nodes/objects/dialogueBox.gd
@@ -54,7 +54,7 @@ func _enter_tree():
 	dialogue = RichTextLabel.new()
 	vbox_container.add_child(dialogue)
 	dialogue.text = 'Sample dialogue.\nLoad a [u]dialogue file[/u].'
-	dialogue.scroll_following = true
+	dialogue.scroll_following = false
 	dialogue.bbcode_enabled = true
 	dialogue.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	dialogue.custom_effects = custom_effects


### PR DESCRIPTION
The idea was sound. As the text appears, the box should be scrolling down. Unfortunately, scroll_following doesn't take into account [wait], so it scrolls immediately at the bottom and looks jarring. I disabled that option, and hope to find an alternative that's smarter. Here's a before-after.

![before](https://github.com/nagidev/DialogueNodes/assets/7960042/deebc5c8-6fbb-4f76-9c4c-463db176f046)
![after](https://github.com/nagidev/DialogueNodes/assets/7960042/9ee58e7a-d82c-4777-a65e-6f430946dbfb)
