### PR TITLE
Fixed Example4 not starting due to wrong start ID.

### DIFF
--- a/examples/Demo.tscn
+++ b/examples/Demo.tscn
@@ -38,6 +38,21 @@ offset_bottom = -26.0
 grow_horizontal = 2
 grow_vertical = 2
 
+[node name="StartSelector" type="OptionButton" parent="."]
+visible = false
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -67.5
+offset_top = -7.0
+offset_right = 67.5
+offset_bottom = 29.0
+grow_horizontal = 2
+grow_vertical = 2
+
 [node name="Button" type="Button" parent="."]
 layout_mode = 1
 anchors_preset = 8
@@ -91,5 +106,6 @@ start_id = "START"
 custom_effects = Array[RichTextEffect]([SubResource("RichTextEffect_fpwbw")])
 
 [connection signal="item_selected" from="DemoSelector" to="." method="_on_demo_selected"]
+[connection signal="item_selected" from="StartSelector" to="." method="_on_start_selected"]
 [connection signal="pressed" from="Button" to="." method="_on_Button_pressed"]
 [connection signal="dialogue_signal" from="DialogueBox" to="." method="_on_dialogue_signal"]

--- a/examples/demo.gd
+++ b/examples/demo.gd
@@ -7,14 +7,24 @@ var demos: Array[String] = [
 	"res://examples/Example4.json"
 ]
 
+var starts: Array[String] = [
+	"SIGNALS",
+	"SETGET",
+	"CONDITION"
+]
+
 @onready var dialogue_box = $DialogueBox
 @onready var particles = $Particles
 
+var selected_start = -1
 
 func _ready():
 	for file in demos:
 		var label = file.split("/")[-1].split(".")[0]
 		$DemoSelector.add_item(label)
+	pass
+	for start in starts:
+		$StartSelector.add_item(start)
 	pass
 
 
@@ -24,7 +34,10 @@ func explode(_a=0):
 
 func _on_Button_pressed():
 	if not dialogue_box.running:
-		dialogue_box.start()
+		if $StartSelector.visible:
+			dialogue_box.start(starts[selected_start])
+		else:
+			dialogue_box.start()
 
 
 func _on_dialogue_signal(value):
@@ -35,3 +48,13 @@ func _on_dialogue_signal(value):
 func _on_demo_selected(index):
 	print("loading file:", demos[index])
 	dialogue_box.load_file(demos[index])
+	if index == 3:
+		$StartSelector.visible = true
+		selected_start = 0
+	else:
+		$StartSelector.visible = false
+		selected_start = -1
+
+func _on_start_selected(index):
+	print("selected start:" + starts[index])
+	selected_start = index


### PR DESCRIPTION
Demo scene expects all examples to start with start_id "START", but Example4 has "SIGNALS", "SETGET" and "CONDITION". Because of that, it'll always return an error. I fixed it by adding a second selected that allows you to start in any of the three trees. Plus, it's a nice showcase of how you can have multiple entry points.