### PR TITLE
Add .gitattributes file for the Godot Asset Library

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Normalize line endings for all files that Git considers text files.
+* text=auto eol=lf
+
+# Only include the addons folder when downloading from the Asset Library.
+/**        export-ignore
+/addons    !export-ignore
+/addons/** !export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,5 @@
 /**        export-ignore
 /addons    !export-ignore
 /addons/** !export-ignore
+/examples    !export-ignore
+/examples/** !export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Godot 4+ specific ignores
+.godot/
 
 # Godot-specific ignores
 .import/
@@ -7,9 +9,8 @@ export_presets.cfg
 # Mono-specific ignores
 .mono/
 data_*/
+
+# Project-specific ignores
 exports/DialogueNodes.exe
 exports/DialogueNodes.pck
 exports/exports.zip
-
-# Project-specific ignores
-.godot


### PR DESCRIPTION
Per the [submission guidelines](https://docs.godotengine.org/en/latest/community/asset_library/submitting_to_assetlib.html), this ensures that only the `addons/` folder is included when downloading from the Godot Asset Library, ensuring that files like `project.godot` are excluded.