### PR TITLE
Added option to disable automatically focusing choices

### DIFF
--- a/addons/dialogue_nodes/objects/dialogueBox.gd
+++ b/addons/dialogue_nodes/objects/dialogueBox.gd
@@ -44,6 +44,9 @@ signal option_selected(idx: int)
 @export_group('Misc')
 ## Input action used to skip dialogue animation
 @export var skip_input_action := 'ui_cancel'
+## When there is more than 1 option in a node, automatically apply focus to the first option. 
+## Disable this if the player should always be required to manually select a choice 
+@export var automatically_focus_choices := true
 ## Speed of scroll when using joystick/keyboard input
 @export var scroll_speed := 4
 ## Hide dialogue box at the end of a dialogue
@@ -546,10 +549,17 @@ func _check_condition(cond_dict: Dictionary):
 func show_options():
 	if options.is_inside_tree():
 		options.show()
+		
+		var visible_option_count = 0
 		for option in options.get_children():
 			if option.visible:
-				option.grab_focus()
-				break
+				visible_option_count += 1
+		
+		if automatically_focus_choices || visible_option_count <= 1:
+			for option in options.get_children():
+				if option.visible:
+					option.grab_focus()
+					break
 
 
 func _set_options_count(value):

--- a/examples/Demo.tscn
+++ b/examples/Demo.tscn
@@ -117,6 +117,7 @@ grow_horizontal = 2
 grow_vertical = 0
 script = ExtResource("8_kplwy")
 start_id = "START"
+automatically_focus_choices = true
 custom_effects = Array[RichTextEffect]([SubResource("RichTextEffect_fpwbw")])
 
 [connection signal="item_selected" from="DemoSelector" to="." method="_on_demo_selected"]


### PR DESCRIPTION
Here is the problem I am trying to solve:

- User is using the Skip Input Action hotkey to navigate through the dialogue
- When they're presented with a choice (>1 option), the first option is automatically focused 
- The next press of the Skip Input Action hotkey automatically selects the first option

In my case, I have found that this makes it very easy to accidentally select an option, especially if you're mashing through dialogue quickly. 

What I've added:
- A new exported bool on DialogueBox called 'Automatically Focus Choices' which can toggle the above behavior on / off
- The default value is true (meaning it will operate how it does today, automatically focusing the first choice)
- If turned off, the Dialogue Box will no longer automatically focus a button when there is >1 option and the user must explicitly select one option. Note that instances of having only 1 option will still be auto-focused. 


Example:
With the option disabled, no choices will be focused 
![image](https://github.com/nagidev/DialogueNodes/assets/97913726/94c574a7-eab7-4106-8886-827a70eb7e10)


With the option enabled (default) the option will be focused
![image](https://github.com/nagidev/DialogueNodes/assets/97913726/c746015d-edeb-458c-ab3c-0e51b8f278ea)
