### PR TITLE
Fixed _process to prevent memory leak

### DIFF
--- a/addons/dialogue_nodes/objects/DialogueBox.gd
+++ b/addons/dialogue_nodes/objects/DialogueBox.gd
@@ -225,7 +225,7 @@ func _ready():
 
 
 func _process(delta):
-	if not is_running: return
+	if not is_running(): return
 	
 	# scrolling for longer dialogues
 	var scroll_amt := 0.0


### PR DESCRIPTION
Updated line 228 in Dialogue_box.gd to be if not is_running(): return to prevent memory leak.