### PR TITLE
Fixed bug causing crash when dialogue is empty

### DIFF
--- a/addons/dialogue_nodes/objects/DialogueParser.gd
+++ b/addons/dialogue_nodes/objects/DialogueParser.gd
@@ -358,6 +358,10 @@ func _parse_variable_names(value: String) -> Array:
 # FIXME : Length calculation is borked when the value has [, ] unrelated to any bbcodes.
 # Updates all the [wait] bbcode tags in the given text to include additional info about the text
 func _update_wait_tags(node: RichTextLabel, value: String) -> String:
+	# Empty string freezes dialogues
+	if value == "":
+		value = " "
+	
 	# add a wait if none present at beginning
 	if not value.begins_with('[wait'):
 		value = '[wait]' + value + '[/wait]'

--- a/addons/dialogue_nodes/objects/DialogueParser.gd
+++ b/addons/dialogue_nodes/objects/DialogueParser.gd
@@ -359,8 +359,8 @@ func _parse_variable_names(value: String) -> Array:
 # Updates all the [wait] bbcode tags in the given text to include additional info about the text
 func _update_wait_tags(node: RichTextLabel, value: String) -> String:
 	# Empty string freezes dialogues
-	if value == "":
-		value = " "
+	if value == '':
+		value = ' '
 	
 	# add a wait if none present at beginning
 	if not value.begins_with('[wait'):


### PR DESCRIPTION
Closes #67 

When adding the BBCode wait tags to an empty string, we never add the `last` property. This causes a failed dictionary lookup for that `last` property which fails and causes a crash.

I added a check for empty string and replaced it with a string that has a single whitespace character since they're functionally the same.